### PR TITLE
feat: restructure endurance section with series, timing, and media sub-sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@
 - [Formula 2 and Formula 3](#formula-2-and-formula-3)
 - [Formula E](#formula-e)
 - [Endurance, WEC, Le Mans, IMSA](#endurance-wec-le-mans-imsa)
+  - [Official Series and Results](#official-series-and-results)
+  - [Timing, Telemetry, and Data](#timing-telemetry-and-data)
+  - [Media and Analysis](#media-and-analysis)
 - [WRC and Rally](#wrc-and-rally)
 - [MotoGP and WorldSBK](#motogp-and-worldsbk)
 - [NASCAR](#nascar)
@@ -224,11 +227,32 @@
 
 ## Endurance, WEC, Le Mans, IMSA
 
-- [Al Kamel Systems](https://alkamelsystems.com/) - Industry-standard timing provider used across endurance racing. [WEC timing host](http://fiawec.alkamelsystems.com/).
-- [IMSA GTP Telemetry](https://www.imsa.com/gtp-telemetry/) - Official telemetry-oriented reference for IMSA's top class.
+### Official Series and Results
+
 - [FIA WEC](https://www.fiawec.com/) - Official site. [Regulations](https://www.fiawec.com/en/page/regulations-1). [Event API](https://api.fia.com/events/world-endurance-championship/).
 - [24 Hours of Le Mans](https://www.24h-lemans.com/) - Official Le Mans site.
 - [IMSA](https://www.imsa.com/) - Official site. [Schedule](https://www.imsa.com/weathertech/weathertech-2026-schedule/). [Regulations](https://www.imsa.com/competitors/2025-imsa-rules-regulations/).
+- [European Le Mans Series](https://www.europeanlemansseries.com/) - Official ELMS site with news, calendar, results, live timing, videos, and standings.
+- [GT World Challenge Europe](https://www.gt-world-challenge-europe.com/) - European GT3 endurance and sprint series with race results, standings, live timing, and team/driver profiles.
+- [Michelin Le Mans Cup](https://www.lemanscup.com/) - Official Le Mans Cup site for LMP3 and GT3 support-series news, results, live timing, videos, and replays.
+- [Asian Le Mans Series](https://www.asianlemansseries.com/) - Official Asian Le Mans Series site with calendar, live coverage, results, standings, entries, and race replays.
+- [24h Nürburgring Results](https://www.24h-rennen.de/en/results/) - Official Nürburgring 24 Hours results archive.
+
+### Timing, Telemetry, and Data
+
+- [Al Kamel Systems](https://alkamelsystems.com/) - Industry-standard timing provider used across endurance racing.
+- [WEC Timing Results](https://fiawec.alkamelsystems.com/) - Official Al Kamel timing archive for FIA WEC sessions, classifications, sector times, speed traps, analysis, and weather reports.
+- [IMSA GTP Telemetry](https://www.imsa.com/gtp-telemetry/) - Official telemetry-oriented reference for IMSA's top class.
+- [ELMS Timing Results](https://elms.alkamelsystems.com/) - Al Kamel timing archive for European Le Mans Series.
+- [Asian Le Mans Series Timing Results](https://alms.alkamelsystems.com/) - Al Kamel timing archive for Asian Le Mans Series.
+- [Racing Sports Cars](https://www.racingsportscars.com/) - Historical sports-car racing database covering Le Mans Series, ALMS, FIA GT, IMSA, Can-Am, and more.
+- [World Sports Racing Prototypes](http://www.wsrp.cz/) - Sportscar racing statistics, results, chassis histories, and car-history reference.
+
+### Media and Analysis
+
+- [Sportscar365](https://sportscar365.com/) - Dedicated sportscar racing news site covering IMSA, FIA WEC, 24 Hours of Le Mans, GT racing, podcasts, and paddock notes.
+- [dailysportscar](https://www.dailysportscar.com/) - Long-running sportscar and GT racing magazine covering FIA WEC, IMSA, ELMS, Super GT, and endurance racing features.
+- [Endurance-Info](https://en.endurance-info.com/) - Endurance racing news, results, photos, live-race coverage, and archives.
 
 ## WRC and Rally
 


### PR DESCRIPTION
## Summary
- Restructures `## Endurance, WEC, Le Mans, IMSA` into three `###` sub-sections (matching the Formula 1 layout): **Official Series and Results**, **Timing, Telemetry, and Data**, **Media and Analysis**.
- Adds 13 new resources (5 series, 5 timing/data, 3 media) and slots the existing WEC, Le Mans, IMSA, Al Kamel, and IMSA GTP entries into the new structure.
- Updates the Contents TOC with nested sub-section entries.

## Ordering rationale
- **Official Series and Results**: top championships first (FIA WEC → 24h Le Mans → IMSA), then European headline series (ELMS, GTWC), support/regional series (Le Mans Cup, Asian LMS), and single-event archive (Nürburgring 24).
- **Timing, Telemetry, and Data**: industry-standard provider (Al Kamel) → top-championship live timing (WEC, IMSA GTP) → series timings (ELMS, Asian LMS) → historical databases (Racing Sports Cars, WSRP).
- **Media and Analysis**: largest dedicated outlet (Sportscar365) → established legacy magazine (dailysportscar) → French/EU-rooted Endurance-Info.

## Verification
- 11/13 new URLs returned `200 OK` against a realistic browser User-Agent.
- `wsrp.cz` was changed to `http://` because the host's TLS certificate is issued for `*.svethostingu.cz` and fails hostname verification over HTTPS; HTTP returns 200 and the site is the canonical historical sportscar database.
- `dailysportscar.com` returns `401` to scripted requests because of StackProtect bot defense (cookie-based challenge) but loads normally in browsers.

## Test plan
- [ ] Visual check: TOC anchors resolve to the three new `###` sub-sections.
- [ ] Spot-check 2-3 links open in a real browser, including `wsrp.cz` and `dailysportscar.com`.